### PR TITLE
[Feature PFM-11] YS | Development push: Patient Flow Manager Screen, Jun 22, 2023

### DIFF
--- a/src/components/AlertInfo.js
+++ b/src/components/AlertInfo.js
@@ -1,0 +1,70 @@
+import React, { useState } from "react";
+import { Image, Alert, Divider, Typography, Space, Row, Col } from "antd";
+const { Title } = Typography;
+
+export const AlertInfo = () => {
+  const [alignment, setAlignment] = useState("start");
+  const [direction, setDirection] = useState("horizontal");
+  return (
+    <>
+      <Alert
+        message="Información del Estatus del Paciente "
+        description={
+          <Row justify="center">
+            <Col xs={24} sm={12} md={8} lg={24} style={{ textAlign: "center" }}>
+              <Space
+                direction={direction}
+                align={alignment === "start" ? "start" : "center"}
+                wrap
+              >
+                <Space>
+                  <Image
+                    preview={false}
+                    src={require("../img/waiting.svg")}
+                    width={20}
+                    height={80}
+                  />
+                  <Title level={5}>{"En espera para atender"}</Title>
+                </Space>
+                <Divider />
+                <Space>
+                  <Image
+                    preview={false}
+                    src={require("../img/in_process.svg")}
+                    width={20}
+                    height={80}
+                  />
+                  <Title level={5}>{"Atendiendo "}</Title>
+                </Space>
+                <Divider />
+                <Space>
+                  <Image
+                    preview={false}
+                    src={require("../img/pay.svg")}
+                    width={20}
+                    height={80}
+                  />
+                  <Title level={5}> {"Servicio Pagado "}</Title>
+                </Space>
+                <Divider />
+                <Space>
+                  <Image
+                    preview={false}
+                    src={require("../img/complete.svg")}
+                    width={20}
+                    height={80}
+                  />
+                  <Title level={5}> {"Visita completada "}</Title>
+                </Space>
+              </Space>
+            </Col>
+          </Row>
+        }
+        type="info"
+        showIcon
+      />
+
+      <Divider />
+    </>
+  );
+};

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,0 +1,1 @@
+export { AlertInfo } from "./AlertInfo";

--- a/src/helpers/stationEnum.js
+++ b/src/helpers/stationEnum.js
@@ -9,8 +9,7 @@ const StationEnum = {
   pha: "Farmacia",
   lab: "Laboratorio",
   pra: "Sala de Procedimientos A",
-  fin: "Finalizar",
-  pay: "Pago",
+  pfm: 'Anfitrión'
 };
 
 export default StationEnum;

--- a/src/helpers/stations.js
+++ b/src/helpers/stations.js
@@ -9,6 +9,5 @@ export const stations = [
   { value: "pha", label: "Farmacia" },
   { value: "lab", label: "Laboratorio" },
   { value: "pra", label: "Práctica" },
-  { value: "pay", label: "Pago" },
-  { value: "fin", label: "Finalizar" },
+  { value: "pfm", label: "Anfitrión" },
 ];

--- a/src/helpers/updateStationStatus.js
+++ b/src/helpers/updateStationStatus.js
@@ -1,0 +1,33 @@
+import { firestore } from "./../helpers/firebaseConfig";
+
+export const handleStatusChange = async (value, hoveredRowKey, station) => {
+  const docPatientRef = firestore.collection("patients").doc(hoveredRowKey);
+
+  if (docPatientRef) {
+    docPatientRef
+      .get()
+      .then((doc) => {
+        if (doc.exists) {
+          const data = doc.data();
+          const updatedPlanOfCare = data.plan_of_care?.map((item) => {
+            if (item.station === station) {
+              return {
+                ...item,
+                status: value,
+              };
+            }
+            return item;
+          });
+
+          docPatientRef.update({
+            plan_of_care: updatedPlanOfCare,
+          });
+        } else {
+          console.log("No such document!");
+        }
+      })
+      .catch((error) => {
+        console.log("Error getting document:", error);
+      });
+  }
+};

--- a/src/index.css
+++ b/src/index.css
@@ -55,3 +55,11 @@ h5 {
 .ant-image-img {
   cursor: pointer !important;
 }
+.ant-popover-title {
+  text-align: center;
+  text-transform: uppercase;
+}
+
+.ant-popover-inner-content {
+  background: #f0f0f0;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -52,3 +52,6 @@
 h5 {
   margin-top: 9px !important;
 }
+.ant-image-img {
+  cursor: pointer !important;
+}

--- a/src/pages/Anfitrion.js
+++ b/src/pages/Anfitrion.js
@@ -1,7 +1,9 @@
 import React, { useEffect, useState } from "react";
-import { Table, Image, Space, Popover } from "antd";
+import { Table, Image, Space, Popover, Divider, Button } from "antd";
+import { CloseCircleOutlined } from "@ant-design/icons";
 import { firestore } from "./../helpers/firebaseConfig";
 import { handleStatusChange } from "./../helpers/updateStationStatus";
+import { useHistory } from "react-router-dom";
 import { useHideMenu } from "../hooks/useHideMenu";
 import StationEnum from "../helpers/stationEnum";
 import { AlertInfo } from "../components/AlertInfo";
@@ -11,6 +13,7 @@ export const Anfitrion = () => {
   const [data, setData] = useState([]);
   const [station, setStation] = useState("");
   const [hoveredRowKey, setHoveredRowKey] = useState(null);
+  const history = useHistory();
 
   const handleMouseEnter = (record) => {
     setHoveredRowKey(record.pt_no);
@@ -18,6 +21,11 @@ export const Anfitrion = () => {
 
   const handleMouseLeave = () => {
     setHoveredRowKey("");
+  };
+
+  const salir = () => {
+    localStorage.clear();
+    history.replace("/ingresar-host");
   };
 
   useEffect(() => {
@@ -269,6 +277,17 @@ export const Anfitrion = () => {
           onMouseLeave: () => handleMouseLeave(),
         })}
       />
+         <Divider>
+        <Button
+          shape="round"
+          type="danger"
+          onClick={salir}
+          style={{ marginTop: "10px" }}
+        >
+          <CloseCircleOutlined />
+          Salir
+        </Button>
+      </Divider>
     </>
   );
 };

--- a/src/pages/Anfitrion.js
+++ b/src/pages/Anfitrion.js
@@ -1,0 +1,321 @@
+import React, { useEffect, useState } from "react";
+import {
+  Table,
+  Image,
+  Alert,
+  Divider,
+  Typography,
+  Space,
+  Row,
+  Col,
+  Popover,
+} from "antd";
+import { firestore } from "./../helpers/firebaseConfig";
+import { useHideMenu } from "../hooks/useHideMenu";
+import StationEnum from "../helpers/stationEnum";
+const { Title } = Typography;
+
+export const Anfitrion = () => {
+  useHideMenu(true);
+  const [data, setData] = useState([]);
+  const [alignment, setAlignment] = useState("start");
+  const [direction, setDirection] = useState("horizontal");
+
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const fetchData = async () => {
+      try {
+        const collectionRef = firestore.collection("patients");
+        const snapshot = await collectionRef.orderBy("start_time").get();
+        const initialData = snapshot.docs.map((doc) => {
+          return doc.data();
+        });
+
+        if (isMounted) {
+          setData(initialData);
+        }
+
+        const unsubscribe = collectionRef.onSnapshot((snapshot) => {
+          const updatedData = snapshot.docs.map((doc) => doc.data());
+
+          if (isMounted) {
+            setData(updatedData);
+          }
+        });
+
+        return () => {
+          unsubscribe();
+          isMounted = false;
+        };
+      } catch (error) {
+        console.log(error);
+      }
+    };
+
+    fetchData();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const renderStatusIcon = (status, record) => {
+    let statusIcon = null;
+    console.log(record);
+    switch (status) {
+      case "pending":
+        statusIcon = (
+          <Popover content={content} title="Cambiar estatus" trigger="hover">
+            <Image
+              src={require("../img/not_planned.svg")}
+              width={20}
+              height={80}
+              preview={false}
+            />
+          </Popover>
+        );
+        break;
+      case "in_process":
+        statusIcon = (
+          <Popover content={content} title="Cambiar estatus" trigger="hover">
+            <Image
+              src={require("../img/in_process.svg")}
+              width={20}
+              height={80}
+              preview={false}
+            />
+          </Popover>
+        );
+        break;
+      case "waiting":
+        statusIcon = (
+          <Popover content={content} title="Cambiar estatus" trigger="hover">
+            <Image
+              src={require("../img/waiting.svg")}
+              width={20}
+              height={80}
+              preview={false}
+            />
+          </Popover>
+        );
+        break;
+      case "pay":
+        statusIcon = (
+          <Popover content={content} title="Cambiar estatus" trigger="hover">
+          <Image
+            src={require("../img/pay.svg")}
+            width={20}
+            height={80}
+            preview={false}
+          />
+        </Popover>
+        );
+        break;
+      case "complete":
+        statusIcon = (
+          <Popover content={content} title="Cambiar estatus" trigger="hover">
+          <Image
+            src={require("../img/complete.svg")}
+            width={20}
+            height={80}
+            preview={false}
+          />
+        </Popover>
+        );
+        break;
+      default:
+        statusIcon = null;
+        break;
+    }
+    return statusIcon;
+  };
+
+  const content = (
+    <Space wrap>
+      <Image
+        src={require("../img/not_planned.svg")}
+        width={20}
+        height={80}
+        preview={false}
+      />
+
+      <Image
+        src={require("../img/in_process.svg")}
+        width={20}
+        height={80}
+        preview={false}
+      />
+
+      <Image
+        src={require("../img/waiting.svg")}
+        width={20}
+        height={80}
+        preview={false}
+      />
+
+      <Image
+        src={require("../img/pay.svg")}
+        width={20}
+        height={80}
+        preview={false}
+      />
+
+      <Image
+        src={require("../img/complete.svg")}
+        width={20}
+        height={80}
+        preview={false}
+      />
+    </Space>
+  );
+
+  const generateTableData = (extractedPlanOfCare) => {
+    const uniqueStations = {};
+    extractedPlanOfCare.forEach((item) => {
+      // eslint-disable-next-line no-unused-expressions
+      item.plan_of_care?.forEach((plan) => {
+        if (!uniqueStations[plan.station]) {
+          uniqueStations[plan.station] = {
+            dataIndex: plan.station,
+            key: plan.station,
+            title: StationEnum[plan.station],
+            render: (status, record) => renderStatusIcon(status),
+            width: 100,
+            align: "center",
+          };
+        }
+      });
+    });
+
+    extractedPlanOfCare.sort((a, b) => {
+      const startTimeA = new Date(a.start_time.toMillis());
+      const startTimeB = new Date(b.start_time.toMillis());
+      return startTimeA - startTimeB;
+    });
+
+    const columns = [
+      {
+        title: "Paciente",
+        dataIndex: "patient_name",
+        key: "patient",
+        width: 100,
+        fixed: "left",
+      },
+      ...Object.values(uniqueStations),
+      {
+        title: "Tiempo de espera",
+        dataIndex: "",
+        key: "",
+        width: 100,
+        fixed: "right",
+      },
+    ];
+
+    const dataSource = extractedPlanOfCare.map((item) => {
+      const stations = {};
+      item.plan_of_care.forEach((plan) => {
+        stations[plan.station] = plan.status;
+      });
+      return {
+        pt_no: item.pt_no,
+        patient_name: item.patient_name,
+        ...stations,
+      };
+    });
+
+    return { columns, dataSource };
+  };
+
+  const { columns, dataSource } = generateTableData(data);
+
+  const handleStatusChange = (record, value) => {
+    const updatedPlanOfCare = record.plan_of_care.map((item) => {
+      if (item.station) {
+        return {
+          ...item,
+          status: value,
+        };
+      }
+      return item;
+    });
+
+    firestore.collection("patients").doc(record.pt_no).update({
+      plan_of_care: updatedPlanOfCare,
+    });
+  };
+
+
+  const getRowClassName = (record, index) => {
+    return index % 2 === 0 ? "even-row" : "odd-row";
+  };
+
+  return (
+    <>
+      <Alert
+        message="Información del Estatus del Paciente "
+        description={
+          <Row justify="center">
+            <Col xs={24} sm={12} md={8} lg={24} style={{ textAlign: "center" }}>
+              <Space
+                direction={direction}
+                align={alignment === "start" ? "start" : "center"}
+                wrap
+              >
+                <Space>
+                  <Image
+                    src={require("../img/waiting.svg")}
+                    width={20}
+                    height={80}
+                  />
+                  <Title level={5}>{"Paciente en espera "}</Title>
+                </Space>
+                <Divider />
+                <Space>
+                  <Image
+                    src={require("../img/in_process.svg")}
+                    width={20}
+                    height={80}
+                  />
+                  <Title level={5}>{"Paciente siendo atendido "}</Title>
+                </Space>
+                <Divider />
+                <Space>
+                  <Image
+                    src={require("../img/pay.svg")}
+                    width={20}
+                    height={80}
+                  />
+                  <Title level={5}> {"Paciente realizó el pago "}</Title>
+                </Space>
+                <Divider />
+                <Space>
+                  <Image
+                    src={require("../img/complete.svg")}
+                    width={20}
+                    height={80}
+                  />
+                  <Title level={5}> {"Paciente completó su visita "}</Title>
+                </Space>
+              </Space>
+            </Col>
+          </Row>
+        }
+        type="info"
+        showIcon
+      />
+
+      <Divider />
+      <Table
+        rowKey={"pt_no"}
+        columns={columns}
+        dataSource={data.some((d) => d === undefined) ? [] : dataSource}
+        scroll={{ x: 1500, y: 1500 }}
+        sticky
+        offsetScroll={3}
+        rowClassName={getRowClassName}
+      />
+    </>
+  );
+};

--- a/src/pages/Anfitrion.js
+++ b/src/pages/Anfitrion.js
@@ -75,7 +75,7 @@ export const Anfitrion = () => {
           <Popover content={content} title="Cambiar estatus" trigger="hover">
             <Image
               src={require("../img/not_planned.svg")}
-              width={20}
+              width={30}
               height={80}
               preview={false}
               onMouseEnter={() => {
@@ -90,7 +90,7 @@ export const Anfitrion = () => {
           <Popover content={content} title="Cambiar estatus" trigger="hover">
             <Image
               src={require("../img/in_process.svg")}
-              width={20}
+              width={30}
               height={80}
               preview={false}
               onMouseEnter={() => {
@@ -105,7 +105,7 @@ export const Anfitrion = () => {
           <Popover content={content} title="Cambiar estatus" trigger="hover">
             <Image
               src={require("../img/waiting.svg")}
-              width={20}
+              width={30}
               height={80}
               preview={false}
               onMouseEnter={() => {
@@ -120,7 +120,7 @@ export const Anfitrion = () => {
           <Popover content={content} title="Cambiar estatus" trigger="hover">
             <Image
               src={require("../img/pay.svg")}
-              width={20}
+              width={30}
               height={80}
               preview={false}
               onMouseEnter={() => {
@@ -135,7 +135,112 @@ export const Anfitrion = () => {
           <Popover content={content} title="Cambiar estatus" trigger="hover">
             <Image
               src={require("../img/complete.svg")}
-              width={20}
+              width={30}
+              height={80}
+              preview={false}
+              onMouseEnter={() => {
+                setStation(station);
+              }}
+            />
+          </Popover>
+        );
+        break;
+      case "1":
+        statusIcon = (
+          <Popover content={content} title="Cambiar estatus" trigger="hover">
+            <Image
+              src={require("../img/1.svg")}
+              width={30}
+              height={80}
+              preview={false}
+              onMouseEnter={() => {
+                setStation(station);
+              }}
+            />
+          </Popover>
+        );
+        break;
+      case "2":
+        statusIcon = (
+          <Popover content={content} title="Cambiar estatus" trigger="hover">
+            <Image
+              src={require("../img/2.svg")}
+              width={30}
+              height={80}
+              preview={false}
+              onMouseEnter={() => {
+                setStation(station);
+              }}
+            />
+          </Popover>
+        );
+        break;
+      case "3":
+        statusIcon = (
+          <Popover content={content} title="Cambiar estatus" trigger="hover">
+            <Image
+              src={require("../img/3.svg")}
+              width={30}
+              height={80}
+              preview={false}
+              onMouseEnter={() => {
+                setStation(station);
+              }}
+            />
+          </Popover>
+        );
+        break;
+      case "4":
+        statusIcon = (
+          <Popover content={content} title="Cambiar estatus" trigger="hover">
+            <Image
+              src={require("../img/4.svg")}
+              width={30}
+              height={80}
+              preview={false}
+              onMouseEnter={() => {
+                setStation(station);
+              }}
+            />
+          </Popover>
+        );
+        break;
+      case "5":
+        statusIcon = (
+          <Popover content={content} title="Cambiar estatus" trigger="hover">
+            <Image
+              src={require("../img/5.svg")}
+              width={30}
+              height={80}
+              preview={false}
+              onMouseEnter={() => {
+                setStation(station);
+              }}
+            />
+          </Popover>
+        );
+        break;
+      case "6":
+        statusIcon = (
+          <Popover content={content} title="Cambiar estatus" trigger="hover">
+            <Image
+              src={require("../img/6.svg")}
+              width={30}
+              height={80}
+              preview={false}
+              onMouseEnter={() => {
+                setStation(station);
+              }}
+            />
+          </Popover>
+        );
+        break;
+      case "7":
+        statusIcon = (
+          <Popover content={content} title="Cambiar estatus" trigger="hover">
+            <Image
+              src={require("../img/7.svg")}
+              width={30}
               height={80}
               preview={false}
               onMouseEnter={() => {
@@ -146,7 +251,19 @@ export const Anfitrion = () => {
         );
         break;
       default:
-        statusIcon = null;
+        statusIcon = (
+          <Popover content={content} title="Cambiar estatus" trigger="hover">
+            <Image
+              src={require("../img/not_planned.svg")}
+              width={30}
+              height={80}
+              preview={false}
+              onMouseEnter={() => {
+                setStation(station);
+              }}
+            />
+          </Popover>
+        );
         break;
     }
     return statusIcon;
@@ -156,7 +273,7 @@ export const Anfitrion = () => {
     <Space wrap>
       <Image
         src={require("../img/not_planned.svg")}
-        width={20}
+        width={30}
         height={80}
         preview={false}
         onClick={() =>
@@ -166,7 +283,7 @@ export const Anfitrion = () => {
 
       <Image
         src={require("../img/in_process.svg")}
-        width={20}
+        width={30}
         height={80}
         preview={false}
         onClick={() => handleStatusChange("in_process", hoveredRowKey, station)}
@@ -174,7 +291,7 @@ export const Anfitrion = () => {
 
       <Image
         src={require("../img/waiting.svg")}
-        width={20}
+        width={30}
         height={80}
         preview={false}
         onClick={() => handleStatusChange("waiting", hoveredRowKey, station)}
@@ -182,7 +299,7 @@ export const Anfitrion = () => {
 
       <Image
         src={require("../img/pay.svg")}
-        width={20}
+        width={30}
         height={80}
         preview={false}
         onClick={() => handleStatusChange("pay", hoveredRowKey, station)}
@@ -190,10 +307,60 @@ export const Anfitrion = () => {
 
       <Image
         src={require("../img/complete.svg")}
-        width={20}
+        width={30}
         height={80}
         preview={false}
         onClick={() => handleStatusChange("complete", hoveredRowKey, station)}
+      />
+
+      <Image
+        src={require("../img/1.svg")}
+        width={30}
+        height={80}
+        preview={false}
+        onClick={() => handleStatusChange("1", hoveredRowKey, station)}
+      />
+      <Image
+        src={require("../img/2.svg")}
+        width={30}
+        height={80}
+        preview={false}
+        onClick={() => handleStatusChange("2", hoveredRowKey, station)}
+      />
+      <Image
+        src={require("../img/3.svg")}
+        width={30}
+        height={80}
+        preview={false}
+        onClick={() => handleStatusChange("3", hoveredRowKey, station)}
+      />
+      <Image
+        src={require("../img/4.svg")}
+        width={30}
+        height={80}
+        preview={false}
+        onClick={() => handleStatusChange("4", hoveredRowKey, station)}
+      />
+      <Image
+        src={require("../img/5.svg")}
+        width={30}
+        height={80}
+        preview={false}
+        onClick={() => handleStatusChange("5", hoveredRowKey, station)}
+      />
+      <Image
+        src={require("../img/6.svg")}
+        width={30}
+        height={80}
+        preview={false}
+        onClick={() => handleStatusChange("6", hoveredRowKey, station)}
+      />
+      <Image
+        src={require("../img/7.svg")}
+        width={30}
+        height={80}
+        preview={false}
+        onClick={() => handleStatusChange("7", hoveredRowKey, station)}
       />
     </Space>
   );
@@ -277,7 +444,7 @@ export const Anfitrion = () => {
           onMouseLeave: () => handleMouseLeave(),
         })}
       />
-         <Divider>
+      <Divider>
         <Button
           shape="round"
           type="danger"

--- a/src/pages/IngresarHost.js
+++ b/src/pages/IngresarHost.js
@@ -71,6 +71,7 @@ export const IngresarHost = () => {
       localStorage.setItem("host", host);
       localStorage.setItem("servicio", servicio);
       history.push("/escritorio");
+      history.push('/anfitrion');
     } catch (error) {
       showAlert("Error", "Error al guardar los datos en Firebase", "error");
     }
@@ -80,8 +81,10 @@ export const IngresarHost = () => {
     console.log("Failed:", errorInfo);
   };
 
-  if (usuario.host && usuario.servicio) {
+  if (usuario.host && usuario.servicio !== 'pfm') {
     return <Redirect to="/escritorio" />;
+  } else if (usuario.host && usuario.servicio === "pfm") {
+    return <Redirect to="/anfitrion" />;
   }
 
   return (
@@ -91,7 +94,7 @@ export const IngresarHost = () => {
           ¡Bienvenido!
         </Title>
         <Title level={2}>Ingresar</Title>
-        <Text>Ingrese su nombre y número de escritorio</Text>
+        <Text>Ingrese su nombre y el servicio a otorgar</Text>
         <Divider />
         <Form
           {...layout}
@@ -104,12 +107,12 @@ export const IngresarHost = () => {
           <Row gutter={24}>
             <Col xs={24} sm={24}>
               <Form.Item
-                label="Nombre del huésped"
+                label="Nombre del usuario"
                 name="host"
                 rules={[
                   {
                     required: true,
-                    message: "Por favor ingrese nombre del huésped",
+                    message: "Por favor ingrese nombre del anfitrión",
                   },
                 ]}
                 {...halfLayout}

--- a/src/pages/IngresarHost.js
+++ b/src/pages/IngresarHost.js
@@ -70,8 +70,12 @@ export const IngresarHost = () => {
 
       localStorage.setItem("host", host);
       localStorage.setItem("servicio", servicio);
-      history.push("/escritorio");
-      history.push('/anfitrion');
+      if (servicio !== 'pfm') {
+        history.push("/escritorio");  
+      } else if (servicio === 'pfm') {
+        // history.push("/escritorio");
+        history.push("/anfitrion");
+      }
     } catch (error) {
       showAlert("Error", "Error al guardar los datos en Firebase", "error");
     }

--- a/src/pages/Registro.js
+++ b/src/pages/Registro.js
@@ -1,4 +1,4 @@
-import React, { useState} from "react";
+import React, { useState } from "react";
 import {
   Form,
   Input,
@@ -62,14 +62,14 @@ export const Registro = () => {
     const currentYear = currentDate.year();
     const currentMonthYear = `${currentMonth}/${currentYear}`;
     const statsRef = firestore.collection("stats").doc(station);
-  
+
     // Obtener el documento de estadísticas de la estación actual
     const statsDoc = await statsRef.get();
-  
+
     if (statsDoc.exists) {
       // El documento de estadísticas ya existe
       const statsData = statsDoc.data();
-  
+
       if (statsData.date !== currentMonthYear) {
         // La fecha es diferente, crear un nuevo documento en la misma colección
         const newStatsRef = firestore.collection("stats").doc();
@@ -95,7 +95,7 @@ export const Registro = () => {
       };
       await statsRef.set(statsData);
     }
-  };  
+  };
 
   const handleChange = (selectedOption) => {
     generateVisits(selectedOption);
@@ -125,7 +125,9 @@ export const Registro = () => {
       wait_time: 0,
     };
 
-    const patientRef = await firestore.collection("patients").add(formattedPatient);
+    const patientRef = await firestore
+      .collection("patients")
+      .add(formattedPatient);
     const ptNo = patientRef.id;
     const updatedPatient = { ...formattedPatient, pt_no: ptNo };
 
@@ -227,7 +229,7 @@ export const Registro = () => {
                   style={{
                     width: "100%",
                   }}
-                  options={stations}
+                  options={stations.slice(0, -1)}
                   onChange={handleChange}
                 />
               </Form.Item>

--- a/src/pages/RouterPage.js
+++ b/src/pages/RouterPage.js
@@ -22,6 +22,7 @@ import { Escritorio } from "./Escritorio";
 import { UiContext } from "../context/UiContext";
 import { IngresarHost } from "./IngresarHost";
 import Stats from "./Stats";
+import { Anfitrion } from "./Anfitrion";
 
 const { Sider, Content, Header } = Layout;
 const { Title } = Typography;
@@ -50,7 +51,7 @@ export const RouterPage = () => {
       label: <Link to="/escritorio">Escritorio</Link>,
     },
     {
-      key: "5",
+      key: "6",
       icon: <BarChartOutlined />,
       label: <Link to="/estadisticas">Estadisticas de hoy</Link>,
     },
@@ -108,6 +109,7 @@ export const RouterPage = () => {
                 <Route path="/turnos" component={Turno} />
                 <Route path="/crear" component={CrearTurno} />
                 <Route path="/escritorio" component={Escritorio} />
+                <Route path="/anfitrion" component={Anfitrion} />
                 <Route path="/estadisticas" component={Stats} />
                 <Redirect to="/ingresar-host" />
               </Switch>

--- a/src/pages/Turno.js
+++ b/src/pages/Turno.js
@@ -16,7 +16,7 @@ export const Turno = () => {
         statusIcon = (
           <Image
             src={require("../img/not_planned.svg")}
-            width={20}
+            width={30}
             height={80}
             preview={false}
           />
@@ -26,7 +26,7 @@ export const Turno = () => {
         statusIcon = (
           <Image
             src={require("../img/in_process.svg")}
-            width={20}
+            width={30}
             height={80}
             preview={false}
           />
@@ -36,7 +36,7 @@ export const Turno = () => {
         statusIcon = (
           <Image
             src={require("../img/waiting.svg")}
-            width={20}
+            width={30}
             height={80}
             preview={false}
           />
@@ -46,7 +46,7 @@ export const Turno = () => {
         statusIcon = (
           <Image
             src={require("../img/pay.svg")}
-            width={20}
+            width={30}
             height={80}
             preview={false}
           />
@@ -56,14 +56,91 @@ export const Turno = () => {
         statusIcon = (
           <Image
             src={require("../img/complete.svg")}
-            width={20}
+            width={30}
+            height={80}
+            preview={false}
+          />
+        );
+        break;
+      case "1":
+        statusIcon = (
+          <Image
+            src={require("../img/1.svg")}
+            width={30}
+            height={80}
+            preview={false}
+          />
+        );
+        break;
+      case "2":
+        statusIcon = (
+          <Image
+            src={require("../img/2.svg")}
+            width={30}
+            height={80}
+            preview={false}
+          />
+        );
+        break;
+      case "3":
+        statusIcon = (
+          <Image
+            src={require("../img/3.svg")}
+            width={30}
+            height={80}
+            preview={false}
+          />
+        );
+        break;
+      case "4":
+        statusIcon = (
+          <Image
+            src={require("../img/4.svg")}
+            width={30}
+            height={80}
+            preview={false}
+          />
+        );
+        break;
+      case "5":
+        statusIcon = (
+          <Image
+            src={require("../img/5.svg")}
+            width={30}
+            height={80}
+            preview={false}
+          />
+        );
+        break;
+      case "6":
+        statusIcon = (
+          <Image
+            src={require("../img/6.svg")}
+            width={30}
+            height={80}
+            preview={false}
+          />
+        );
+        break;
+      case "7":
+        statusIcon = (
+          <Image
+            src={require("../img/7.svg")}
+            width={30}
             height={80}
             preview={false}
           />
         );
         break;
       default:
-        statusIcon = null;
+        statusIcon = (
+          <Image
+            src={require("../img/not_planned.svg")}
+            width={30}
+            height={80}
+            preview={false}
+          />
+        );
         break;
     }
     return statusIcon;

--- a/src/pages/Turno.js
+++ b/src/pages/Turno.js
@@ -1,24 +1,13 @@
 import React, { useEffect, useState } from "react";
-import {
-  Table,
-  Image,
-  Alert,
-  Divider,
-  Typography,
-  Space,
-  Row,
-  Col,
-} from "antd";
+import { Table, Image } from "antd";
 import { firestore } from "./../helpers/firebaseConfig";
 import { useHideMenu } from "../hooks/useHideMenu";
 import StationEnum from "../helpers/stationEnum";
-const { Title } = Typography;
+import { AlertInfo } from "../components/AlertInfo";
 
 export const Turno = () => {
   useHideMenu(true);
   const [data, setData] = useState([]);
-  const [alignment, setAlignment] = useState("start");
-  const [direction, setDirection] = useState("horizontal");
 
   const renderStatusIcon = (status) => {
     let statusIcon = null;
@@ -29,6 +18,7 @@ export const Turno = () => {
             src={require("../img/not_planned.svg")}
             width={20}
             height={80}
+            preview={false}
           />
         );
         break;
@@ -38,22 +28,38 @@ export const Turno = () => {
             src={require("../img/in_process.svg")}
             width={20}
             height={80}
+            preview={false}
           />
         );
         break;
       case "waiting":
         statusIcon = (
-          <Image src={require("../img/waiting.svg")} width={20} height={80} />
+          <Image
+            src={require("../img/waiting.svg")}
+            width={20}
+            height={80}
+            preview={false}
+          />
         );
         break;
       case "pay":
         statusIcon = (
-          <Image src={require("../img/pay.svg")} width={20} height={80} />
+          <Image
+            src={require("../img/pay.svg")}
+            width={20}
+            height={80}
+            preview={false}
+          />
         );
         break;
       case "complete":
         statusIcon = (
-          <Image src={require("../img/complete.svg")} width={20} height={80} />
+          <Image
+            src={require("../img/complete.svg")}
+            width={20}
+            height={80}
+            preview={false}
+          />
         );
         break;
       default:
@@ -65,6 +71,11 @@ export const Turno = () => {
 
   const generateTableData = (extractedPlanOfCare) => {
     const uniqueStations = {};
+    extractedPlanOfCare.sort((a, b) => {
+      const startTimeA = new Date(a.start_time.toMillis());
+      const startTimeB = new Date(b.start_time.toMillis());
+      return startTimeA - startTimeB;
+    });
     extractedPlanOfCare.forEach((item) => {
       // eslint-disable-next-line no-unused-expressions
       item.plan_of_care?.forEach((plan) => {
@@ -79,12 +90,6 @@ export const Turno = () => {
           };
         }
       });
-    });
-
-    extractedPlanOfCare.sort((a, b) => {
-      const startTimeA = new Date(a.start_time.toMillis());
-      const startTimeB = new Date(b.start_time.toMillis());
-      return startTimeA - startTimeB;
     });
 
     const columns = [
@@ -167,60 +172,7 @@ export const Turno = () => {
 
   return (
     <>
-      <Alert
-        message="Información del Estatus del Paciente "
-        description={
-          <Row justify="center">
-            <Col xs={24} sm={12} md={8} lg={24} style={{ textAlign: "center" }}>
-              <Space
-                direction={direction}
-                align={alignment === "start" ? "start" : "center"}
-                wrap
-              >
-                <Space>
-                  <Image
-                    src={require("../img/waiting.svg")}
-                    width={20}
-                    height={80}
-                  />
-                  <Title level={5}>{"Paciente en espera "}</Title>
-                </Space>
-                <Divider />
-                <Space>
-                  <Image
-                    src={require("../img/in_process.svg")}
-                    width={20}
-                    height={80}
-                  />
-                  <Title level={5}>{"Paciente siendo atendido "}</Title>
-                </Space>
-                <Divider />
-                <Space>
-                  <Image
-                    src={require("../img/pay.svg")}
-                    width={20}
-                    height={80}
-                  />
-                  <Title level={5}> {"Paciente realizó el pago "}</Title>
-                </Space>
-                <Divider />
-                <Space>
-                  <Image
-                    src={require("../img/complete.svg")}
-                    width={20}
-                    height={80}
-                  />
-                  <Title level={5}> {"Paciente completó su visita "}</Title>
-                </Space>
-              </Space>
-            </Col>
-          </Row>
-        }
-        type="info"
-        showIcon
-      />
-
-      <Divider />
+      <AlertInfo />
       <Table
         rowKey={"pt_no"}
         columns={columns}


### PR DESCRIPTION
**Description**

- Hacer un apartado de un patient flow manager el cual tendrá una tabla editable como la de la pantalla de turnos.
- Reutilizar la pantalla de flujo de los pacientes.
- Hacer validación en la pantalla de ingresar-host.
- Verificar el estatus del paciente con los números en el arreglo de status.
```
` status_list = [
    'not_planned',

    'planned',

    'waiting',

    'in_process',

    'complete',

    '2',

    '3',

    '4',

    '5',

    '6',

    '7',

  ];`
```
-  Quitar los campos de pago y finalizado (el icono solamente será un estatus).

**Jira issue**

-  https://alfarero.atlassian.net/browse/PFM-11

**Feature**
[add: :sparkles: new anfitrion screen and functionality]

[add: :sparkles: logica de redirección para anfitriones y botón para salir de esa pantalla]

** Feat**
[ feat :triangular_flag_on_post:: Anfitrion Page Updated]

**Fix**
[fix :bug:: Anfitrion page updated]
