### PR TITLE
[Feature PFM-9.1] CG | Development push: Algoritmo del tiempo (visita de pacientes), Jun 26, 2023

### DIFF
--- a/src/helpers/updateStationStatus.js
+++ b/src/helpers/updateStationStatus.js
@@ -4,30 +4,134 @@ export const handleStatusChange = async (value, hoveredRowKey, station) => {
   const docPatientRef = firestore.collection("patients").doc(hoveredRowKey);
 
   if (docPatientRef) {
-    docPatientRef
-      .get()
-      .then((doc) => {
-        if (doc.exists) {
-          const data = doc.data();
-          const updatedPlanOfCare = data.plan_of_care?.map((item) => {
-            if (item.station === station) {
-              return {
-                ...item,
-                status: value,
-              };
-            }
-            return item;
-          });
+    try {
+      const doc = await docPatientRef.get();
 
-          docPatientRef.update({
-            plan_of_care: updatedPlanOfCare,
-          });
-        } else {
-          console.log("No such document!");
+      if (doc.exists) {
+        const data = doc.data();
+        const updatedPlanOfCare = data.plan_of_care?.map((item) => {
+          if (item.station === station) {
+            const updatedItem = {
+              ...item,
+              status: value,
+            };
+
+            if (value === "waiting" && item.status !== "waiting") {
+              updatedItem.wait_start = Math.floor(Date.now() / 1000);
+            } else if (value === "in_process" && item.status !== "in_process") {
+              updatedItem.procedure_start = Math.floor(Date.now() / 1000);
+            } else if (value !== "waiting" && item.status === "waiting") {
+              updatedItem.wait_end = Math.floor(Date.now() / 1000);
+              updatedItem.waiting_time = Math.abs(
+                updatedItem.wait_end - updatedItem.wait_start
+              );
+            } else if (value !== "in_process" && item.status === "in_process") {
+              updatedItem.procedure_end = Math.floor(Date.now() / 1000);
+              updatedItem.procedure_time = Math.abs(
+                updatedItem.procedure_end - updatedItem.procedure_start
+              );
+            }
+
+            return updatedItem;
+          }
+
+          return item;
+        });
+
+        await docPatientRef.update({
+          plan_of_care: updatedPlanOfCare,
+        });
+
+        const statsDocRef = firestore.collection("stats").doc(station);
+        const statsDoc = await statsDocRef.get();
+
+        if (statsDoc.exists) {
+          const statsData = statsDoc.data();
+          const updatedItem = updatedPlanOfCare.find(
+            (item) => item.station === station
+          );
+
+          if (
+            value === "waiting" &&
+            updatedItem.wait_start &&
+            updatedItem.wait_end
+          ) {
+            const waitDifference = Math.abs(updatedItem.waiting_time);
+            await statsDocRef.update({
+              waiting_time_data: [
+                ...(statsData.waiting_time_data || []),
+                waitDifference,
+              ].filter((time) => !isNaN(time)),
+            });
+          }
+
+          if (
+            value === "in_process" &&
+            updatedItem.procedure_start &&
+            updatedItem.procedure_end
+          ) {
+            const inProcessDifference = Math.abs(updatedItem.procedure_time);
+            await statsDocRef.update({
+              procedure_time_data: [
+                ...(statsData.procedure_time_data || []),
+                inProcessDifference,
+              ].filter((time) => !isNaN(time)),
+            });
+          }
+
+          const { waiting_time_data, procedure_time_data, number_of_patients } =
+            statsData;
+
+          if (waiting_time_data && number_of_patients) {
+            const validWaitingTimeData = waiting_time_data.filter(
+              (time) => !isNaN(time)
+            );
+            const waitingAverage = Math.floor(
+              validWaitingTimeData.reduce((acc, time) => acc + time, 0) /
+                number_of_patients
+            );
+            await statsDocRef.update({
+              avg_waiting_time: waitingAverage,
+            });
+            await firestore
+              .collection("patients")
+              .doc(hoveredRowKey)
+              .update({
+                avg_time: Math.floor(waitingAverage / 60),
+              });
+          }
+
+          if (procedure_time_data && number_of_patients) {
+            const validProcedureTimeData = procedure_time_data.filter(
+              (time) => !isNaN(time)
+            );
+            const procedureAverage = Math.floor(
+              validProcedureTimeData.reduce((acc, time) => acc + time, 0) /
+                number_of_patients
+            );
+            await statsDocRef.update({
+              avg_procedure_time: procedureAverage,
+            });
+
+            if (value === "in_process") {
+              await firestore
+                .collection("patients")
+                .doc(hoveredRowKey)
+                .update({
+                  avg_time: Math.floor(procedureAverage / 60),
+                });
+            } else if (value !== "in_process" && value !== "waiting") {
+              await firestore.collection("patients").doc(hoveredRowKey).update({
+                avg_time: 0,
+              });
+            }
+          }
         }
-      })
-      .catch((error) => {
-        console.log("Error getting document:", error);
-      });
+      } else {
+        console.log("No such document!");
+      }
+    } catch (error) {
+      console.log("Error getting document:", error);
+    }
   }
 };

--- a/src/pages/Anfitrion.js
+++ b/src/pages/Anfitrion.js
@@ -7,6 +7,7 @@ import { useHistory } from "react-router-dom";
 import { useHideMenu } from "../hooks/useHideMenu";
 import StationEnum from "../helpers/stationEnum";
 import { AlertInfo } from "../components/AlertInfo";
+import Footer from "./Footer";
 
 export const Anfitrion = () => {
   useHideMenu(true);
@@ -527,6 +528,7 @@ export const Anfitrion = () => {
           Salir
         </Button>
       </Divider>
+      <Footer />
     </>
   );
 };

--- a/src/pages/Escritorio.js
+++ b/src/pages/Escritorio.js
@@ -11,9 +11,7 @@ import {
   Switch,
   Select,
 } from "antd";
-import {
-  CloseCircleOutlined,
-} from "@ant-design/icons";
+import { CloseCircleOutlined } from "@ant-design/icons";
 import { useHideMenu } from "../hooks/useHideMenu";
 import { getUsuarioStorage } from "../helpers/getUsuarioStorage";
 import { Redirect, useHistory } from "react-router-dom";
@@ -102,7 +100,7 @@ export const Escritorio = () => {
       record.plan_of_care.find((item) => item.station === usuario.servicio)
         ?.status || "";
     let statusIcon = null;
-  
+
     switch (currentStatus) {
       case "waiting":
         statusIcon = (
@@ -138,16 +136,16 @@ export const Escritorio = () => {
         statusIcon = null;
         break;
     }
-  
+
     return statusIcon;
   };
-  
+
   useHideMenu(false);
-  
+
   if (!usuario.host || !usuario.servicio) {
     return <Redirect to="/ingresar-host" />;
   }
-  
+
   const columns = [
     {
       title: "Nombre del paciente",
@@ -208,96 +206,133 @@ export const Escritorio = () => {
       ),
     },
   ];
-  
+
   const handleCompleteChange = (record) => {
     const updatedComplete = !record.complete;
-  
+
     firestore.collection("patients").doc(record.pt_no).update({
       complete: updatedComplete,
     });
   };
-//
-const handleStatusChange = async (record, value) => {
-  const currentStation = usuario.servicio;
-  const updatedPlanOfCare = record.plan_of_care.map((item) => {
-    if (item.station === currentStation) {
-      const updatedItem = {
-        ...item,
-        status: value,
-      };
+  //
+  const handleStatusChange = async (record, value) => {
+    const currentStation = usuario.servicio;
+    const updatedPlanOfCare = record.plan_of_care.map((item) => {
+      if (item.station === currentStation) {
+        const updatedItem = {
+          ...item,
+          status: value,
+        };
 
-      if (value === "waiting" && item.status !== "waiting") {
-        updatedItem.wait_start = Math.floor(Date.now() / 1000);
-      } else if (value === "in_process" && item.status !== "in_process") {
-        updatedItem.procedure_start = Math.floor(Date.now() / 1000);
-      } else if (value !== "waiting" && item.status === "waiting") {
-        updatedItem.wait_end = Math.floor(Date.now() / 1000);
-        updatedItem.waiting_time = Math.abs(updatedItem.wait_end - updatedItem.wait_start);
-      } else if (value !== "in_process" && item.status === "in_process") {
-        updatedItem.procedure_end = Math.floor(Date.now() / 1000);
-        updatedItem.procedure_time = Math.abs(updatedItem.procedure_end - updatedItem.procedure_start);
+        if (value === "waiting" && item.status !== "waiting") {
+          updatedItem.wait_start = Math.floor(Date.now() / 1000);
+        } else if (value === "in_process" && item.status !== "in_process") {
+          updatedItem.procedure_start = Math.floor(Date.now() / 1000);
+        } else if (value !== "waiting" && item.status === "waiting") {
+          updatedItem.wait_end = Math.floor(Date.now() / 1000);
+          updatedItem.waiting_time = Math.abs(
+            updatedItem.wait_end - updatedItem.wait_start
+          );
+        } else if (value !== "in_process" && item.status === "in_process") {
+          updatedItem.procedure_end = Math.floor(Date.now() / 1000);
+          updatedItem.procedure_time = Math.abs(
+            updatedItem.procedure_end - updatedItem.procedure_start
+          );
+        }
+
+        return updatedItem;
       }
 
-      return updatedItem;
+      return item;
+    });
+
+    await firestore.collection("patients").doc(record.pt_no).update({
+      plan_of_care: updatedPlanOfCare,
+    });
+
+    const statsDocRef = firestore.collection("stats").doc(currentStation);
+    const doc = await statsDocRef.get();
+
+    if (doc.exists) {
+      const statsData = doc.data();
+      const updatedItem = updatedPlanOfCare.find(
+        (item) => item.station === currentStation
+      );
+
+      if (
+        value === "waiting" &&
+        updatedItem.wait_start &&
+        updatedItem.wait_end
+      ) {
+        const waitDifference = Math.abs(updatedItem.waiting_time);
+        await statsDocRef.update({
+          waiting_time_data: [
+            ...(statsData.waiting_time_data || []),
+            waitDifference,
+          ].filter((time) => !isNaN(time)),
+        });
+      }
+
+      if (
+        value === "in_process" &&
+        updatedItem.procedure_start &&
+        updatedItem.procedure_end
+      ) {
+        const inProcessDifference = Math.abs(updatedItem.procedure_time);
+        await statsDocRef.update({
+          procedure_time_data: [
+            ...(statsData.procedure_time_data || []),
+            inProcessDifference,
+          ].filter((time) => !isNaN(time)),
+        });
+      }
+
+      const { waiting_time_data, procedure_time_data, number_of_patients } =
+        statsData;
+
+      if (waiting_time_data && number_of_patients) {
+        const validWaitingTimeData = waiting_time_data.filter(
+          (time) => !isNaN(time)
+        );
+        const waitingAverage = Math.floor(
+          validWaitingTimeData.reduce((acc, time) => acc + time, 0) /
+            validWaitingTimeData.length
+        );
+        await statsDocRef.update({
+          avg_waiting_time: waitingAverage,
+        });
+
+        // Guardar el promedio también en la colección "patients"
+        await firestore
+          .collection("patients")
+          .doc(record.pt_no)
+          .update({
+            avg_waiting_time: Math.floor(waitingAverage / 60),
+          });
+      }
+
+      if (procedure_time_data && number_of_patients) {
+        const validProcedureTimeData = procedure_time_data.filter(
+          (time) => !isNaN(time)
+        );
+        const procedureAverage = Math.floor(
+          validProcedureTimeData.reduce((acc, time) => acc + time, 0) /
+            validProcedureTimeData.length
+        );
+        await statsDocRef.update({
+          avg_procedure_time: procedureAverage,
+        });
+
+        // Guardar el promedio también en la colección "patients"
+        await firestore
+          .collection("patients")
+          .doc(record.pt_no)
+          .update({
+            avg_procedure_time: Math.floor(procedureAverage / 60),
+          });
+      }
     }
-
-    return item;
-  });
-
-  await firestore.collection("patients").doc(record.pt_no).update({
-    plan_of_care: updatedPlanOfCare,
-  });
-
-  const statsDocRef = firestore.collection("stats").doc(currentStation);
-  const doc = await statsDocRef.get();
-
-  if (doc.exists) {
-    const statsData = doc.data();
-    const updatedItem = updatedPlanOfCare.find((item) => item.station === currentStation);
-
-    if (value === "waiting" && updatedItem.wait_start && updatedItem.wait_end) {
-      const waitDifference = Math.abs(updatedItem.waiting_time);
-      await statsDocRef.update({
-        waiting_time_data: [...(statsData.waiting_time_data || []), waitDifference].filter((time) => !isNaN(time)),
-      });
-    }
-
-    if (value === "in_process" && updatedItem.procedure_start && updatedItem.procedure_end) {
-      const inProcessDifference = Math.abs(updatedItem.procedure_time);
-      await statsDocRef.update({
-        procedure_time_data: [...(statsData.procedure_time_data || []), inProcessDifference].filter((time) => !isNaN(time)),
-      });
-    }
-
-    const { waiting_time_data, procedure_time_data, number_of_patients } = statsData;
-
-    if (waiting_time_data && number_of_patients) {
-      const validWaitingTimeData = waiting_time_data.filter((time) => !isNaN(time));
-      const waitingAverage = Math.floor(validWaitingTimeData.reduce((acc, time) => acc + time, 0) / validWaitingTimeData.length);
-      await statsDocRef.update({
-        avg_waiting_time: waitingAverage,
-      });
-
-      // Guardar el promedio también en la colección "patients"
-      await firestore.collection("patients").doc(record.pt_no).update({
-        avg_waiting_time: Math.floor(waitingAverage/60),
-      });
-    }
-
-    if (procedure_time_data && number_of_patients) {
-      const validProcedureTimeData = procedure_time_data.filter((time) => !isNaN(time));
-      const procedureAverage = Math.floor(validProcedureTimeData.reduce((acc, time) => acc + time, 0) / validProcedureTimeData.length);
-      await statsDocRef.update({
-        avg_procedure_time: procedureAverage,
-      });
-
-      // Guardar el promedio también en la colección "patients"
-      await firestore.collection("patients").doc(record.pt_no).update({
-        avg_procedure_time: Math.floor(procedureAverage / 60),
-      });
-    }
-  }
-};
+  };
 
   const getRowClassName = (record, index) => {
     return index % 2 === 0 ? "even-row" : "odd-row";

--- a/src/pages/Escritorio.js
+++ b/src/pages/Escritorio.js
@@ -276,6 +276,11 @@ const handleStatusChange = async (record, value) => {
       await statsDocRef.update({
         avg_waiting_time: waitingAverage,
       });
+
+      // Guardar el promedio también en la colección "patients"
+      await firestore.collection("patients").doc(record.pt_no).update({
+        avg_waiting_time: waitingAverage,
+      });
     }
 
     if (procedure_time_data && number_of_patients) {
@@ -283,10 +288,14 @@ const handleStatusChange = async (record, value) => {
       await statsDocRef.update({
         avg_procedure_time: procedureAverage,
       });
+
+      // Guardar el promedio también en la colección "patients"
+      await firestore.collection("patients").doc(record.pt_no).update({
+        avg_procedure_time: procedureAverage,
+      });
     }
   }
 };
-
 
   const getRowClassName = (record, index) => {
     return index % 2 === 0 ? "even-row" : "odd-row";

--- a/src/pages/Escritorio.js
+++ b/src/pages/Escritorio.js
@@ -307,7 +307,7 @@ export const Escritorio = () => {
         );
         const waitingAverage = Math.floor(
           validWaitingTimeData.reduce((acc, time) => acc + time, 0) /
-            validWaitingTimeData.length
+            number_of_patients
         );
         await statsDocRef.update({
           avg_waiting_time: waitingAverage,
@@ -318,7 +318,7 @@ export const Escritorio = () => {
           .collection("patients")
           .doc(record.pt_no)
           .update({
-            avg_waiting_time: Math.floor(waitingAverage / 60),
+            avg_time: Math.floor(waitingAverage / 60),
           });
       }
 
@@ -328,19 +328,21 @@ export const Escritorio = () => {
         );
         const procedureAverage = Math.floor(
           validProcedureTimeData.reduce((acc, time) => acc + time, 0) /
-            validProcedureTimeData.length
+            number_of_patients
         );
         await statsDocRef.update({
           avg_procedure_time: procedureAverage,
         });
 
-        // Guardar el promedio también en la colección "patients"
+        if (value === 'in_process') {
+
         await firestore
           .collection("patients")
           .doc(record.pt_no)
           .update({
-            avg_procedure_time: Math.floor(procedureAverage / 60),
+            avg_time: Math.floor(procedureAverage / 60),
           });
+        }
       }
     }
   };

--- a/src/pages/Escritorio.js
+++ b/src/pages/Escritorio.js
@@ -334,13 +334,16 @@ export const Escritorio = () => {
           avg_procedure_time: procedureAverage,
         });
 
-        if (value === 'in_process') {
-
-        await firestore
-          .collection("patients")
-          .doc(record.pt_no)
-          .update({
-            avg_time: Math.floor(procedureAverage / 60),
+        if (value === "in_process") {
+          await firestore
+            .collection("patients")
+            .doc(record.pt_no)
+            .update({
+              avg_time: Math.floor(procedureAverage / 60),
+            });
+        } else if (value !== "in_process" && value !== "waiting") {
+          await firestore.collection("patients").doc(record.pt_no).update({
+            avg_time: 0,
           });
         }
       }

--- a/src/pages/Escritorio.js
+++ b/src/pages/Escritorio.js
@@ -132,6 +132,16 @@ export const Escritorio = () => {
           />
         );
         break;
+      case "pay":
+        statusIcon = (
+          <Image
+            src={require("../img/pay.svg")}
+            width={15}
+            height={10}
+            preview={false}
+          />
+        );
+        break;
       default:
         statusIcon = null;
         break;
@@ -187,6 +197,7 @@ export const Escritorio = () => {
             <Option value="in_process">Atendiendo</Option>
             <Option value="waiting">En espera</Option>
             <Option value="complete">Finalizado</Option>
+            <Option value="pay">Pagando</Option>
           </Select>
         </div>
       ),

--- a/src/pages/Footer.js
+++ b/src/pages/Footer.js
@@ -54,10 +54,10 @@ const Footer = () => {
             <strong>Estacion:</strong> {stat.station_type}
           </p>
           <p>
-            <strong>Espera:</strong> {stat.avg_waiting_time} minutos
+            <strong>Espera:</strong> {stat.avg_waiting_time} segundos
           </p>
           <p>
-            <strong>Proceso:</strong> {stat.avg_procedure_time} minutos
+            <strong>Proceso:</strong> {stat.avg_procedure_time} segundos
           </p>
         </Card>
       ))}

--- a/src/pages/Footer.js
+++ b/src/pages/Footer.js
@@ -33,12 +33,32 @@ const Footer = () => {
   };
 
   return (
-    <div style={{ display: "flex", flexWrap: "wrap" }}>
+    <div
+      style={{
+        display: "flex",
+        flexWrap: "wrap",
+        justifyContent: "center", // Centra las tarjetas horizontalmente
+      }}
+    >
       {filteredStats.map((stat, index) => (
-        <Card key={index} style={{ margin: 8, width: 300 }}>
-          <p><strong>Estacion:</strong> {stat.station_type}</p>
-          <p><strong>Promedio de espera:</strong> {stat.avg_waiting_time}</p>
-          <p><strong>Promedio del proceso:</strong> {stat.avg_procedure_time}</p>
+        <Card
+          key={index}
+          style={{
+            margin: 8,
+            flexBasis: 180, // Establece el ancho inicial de la tarjeta
+            flexGrow: 1, // Permite que la tarjeta crezca si hay espacio disponible
+            maxWidth: 180, // Establece el ancho máximo de la tarjeta
+          }}
+        >
+          <p>
+            <strong>Estacion:</strong> {stat.station_type}
+          </p>
+          <p>
+            <strong>Espera:</strong> {stat.avg_waiting_time} minutos
+          </p>
+          <p>
+            <strong>Proceso:</strong> {stat.avg_procedure_time} minutos
+          </p>
         </Card>
       ))}
     </div>
@@ -46,4 +66,3 @@ const Footer = () => {
 };
 
 export default Footer;
-

--- a/src/pages/Footer.js
+++ b/src/pages/Footer.js
@@ -1,0 +1,49 @@
+import React, { useEffect, useState } from "react";
+import { firestore } from "./../helpers/firebaseConfig";
+import { Card } from "antd";
+
+const Footer = () => {
+  const [stats, setStats] = useState([]);
+
+  useEffect(() => {
+    const fetchStats = async () => {
+      try {
+        const collectionRef = firestore.collection("stats");
+        const snapshot = await collectionRef.get();
+        const statsData = snapshot.docs.map((doc) => doc.data());
+        setStats(statsData);
+      } catch (error) {
+        console.log(error);
+      }
+    };
+
+    fetchStats();
+  }, []);
+
+  const filteredStats = stats.filter(
+    (stat) =>
+      stat.station_type &&
+      stat.average_waiting_seconds !== undefined &&
+      stat.average_procedure_seconds !== undefined
+  );
+
+  const formatTimeInMinutes = (timeInSeconds) => {
+    const minutes = Math.floor(timeInSeconds / 60);
+    return `${minutes} minutos`;
+  };
+
+  return (
+    <div style={{ display: "flex", flexWrap: "wrap" }}>
+      {filteredStats.map((stat, index) => (
+        <Card key={index} style={{ margin: 8, width: 300 }}>
+          <p><strong>Estacion:</strong> {stat.station_type}</p>
+          <p><strong>Tiempo promedio de espera:</strong> {formatTimeInMinutes(stat.average_waiting_seconds)}</p>
+          <p><strong>Tiempo promedio del proceso:</strong> {formatTimeInMinutes(stat.average_procedure_seconds)}</p>
+        </Card>
+      ))}
+    </div>
+  );
+};
+
+export default Footer;
+

--- a/src/pages/Footer.js
+++ b/src/pages/Footer.js
@@ -23,8 +23,8 @@ const Footer = () => {
   const filteredStats = stats.filter(
     (stat) =>
       stat.station_type &&
-      stat.average_waiting_seconds !== undefined &&
-      stat.average_procedure_seconds !== undefined
+      stat.avg_procedure_time !== undefined &&
+      stat.avg_waiting_time !== undefined
   );
 
   const formatTimeInMinutes = (timeInSeconds) => {
@@ -37,8 +37,8 @@ const Footer = () => {
       {filteredStats.map((stat, index) => (
         <Card key={index} style={{ margin: 8, width: 300 }}>
           <p><strong>Estacion:</strong> {stat.station_type}</p>
-          <p><strong>Tiempo promedio de espera:</strong> {formatTimeInMinutes(stat.average_waiting_seconds)}</p>
-          <p><strong>Tiempo promedio del proceso:</strong> {formatTimeInMinutes(stat.average_procedure_seconds)}</p>
+          <p><strong>Promedio de espera:</strong> {stat.avg_waiting_time}</p>
+          <p><strong>Promedio del proceso:</strong> {stat.avg_procedure_time}</p>
         </Card>
       ))}
     </div>

--- a/src/pages/Footer.js
+++ b/src/pages/Footer.js
@@ -2,6 +2,8 @@ import React, { useEffect, useState } from "react";
 import { firestore } from "./../helpers/firebaseConfig";
 import { Card } from "antd";
 
+import StationEnum from "./../helpers/stationEnum";
+
 const Footer = () => {
   const [stats, setStats] = useState([]);
 
@@ -27,6 +29,16 @@ const Footer = () => {
       stat.avg_waiting_time !== undefined
   );
 
+  const formatTime = (seconds) => {
+    const minutes = Math.floor(seconds / 60);
+    const remainingSeconds = seconds % 60;
+    return `${minutes.toString().padStart(2, "0")}:${remainingSeconds.toString().padStart(2, "0")}`;
+  };
+
+  const getStationName = (stationCode) => {
+    return StationEnum[stationCode] || "";
+  };
+
   return (
     <div
       style={{
@@ -46,13 +58,13 @@ const Footer = () => {
           }}
         >
           <p>
-            <strong>Estacion:</strong> {stat.station_type}
+            <strong>{getStationName(stat.station_type)}</strong> 
           </p>
           <p>
-            <strong>Espera:</strong> {stat.avg_waiting_time} segundos
+            <strong>Espera:</strong> {formatTime(stat.avg_waiting_time)} (mm:ss)
           </p>
           <p>
-            <strong>Proceso:</strong> {stat.avg_procedure_time} segundos
+            <strong>Proceso:</strong> {formatTime(stat.avg_procedure_time)} (mm:ss)
           </p>
         </Card>
       ))}
@@ -61,3 +73,4 @@ const Footer = () => {
 };
 
 export default Footer;
+

--- a/src/pages/Footer.js
+++ b/src/pages/Footer.js
@@ -27,11 +27,6 @@ const Footer = () => {
       stat.avg_waiting_time !== undefined
   );
 
-  const formatTimeInMinutes = (timeInSeconds) => {
-    const minutes = Math.floor(timeInSeconds / 60);
-    return `${minutes} minutos`;
-  };
-
   return (
     <div
       style={{

--- a/src/pages/IngresarHost.js
+++ b/src/pages/IngresarHost.js
@@ -104,12 +104,12 @@ export const IngresarHost = () => {
           <Row gutter={24}>
             <Col xs={24} sm={24}>
               <Form.Item
-                label="Nombre del huésped"
+                label="Nombre del anfitrión"
                 name="host"
                 rules={[
                   {
                     required: true,
-                    message: "Por favor ingrese nombre del huésped",
+                    message: "Por favor ingrese nombre del anfitrión",
                   },
                 ]}
                 {...halfLayout}

--- a/src/pages/IngresarHost.js
+++ b/src/pages/IngresarHost.js
@@ -104,12 +104,12 @@ export const IngresarHost = () => {
           <Row gutter={24}>
             <Col xs={24} sm={24}>
               <Form.Item
-                label="Nombre del anfitrión"
+                label="Nombre"
                 name="host"
                 rules={[
                   {
                     required: true,
-                    message: "Por favor ingrese nombre del anfitrión",
+                    message: "Por favor ingrese nombre",
                   },
                 ]}
                 {...halfLayout}

--- a/src/pages/Registro.js
+++ b/src/pages/Registro.js
@@ -1,4 +1,4 @@
-import React, { useState} from "react";
+import React, { useState } from "react";
 import {
   Form,
   Input,
@@ -62,14 +62,14 @@ export const Registro = () => {
     const currentYear = currentDate.year();
     const currentMonthYear = `${currentMonth}/${currentYear}`;
     const statsRef = firestore.collection("stats").doc(station);
-  
+
     // Obtener el documento de estadísticas de la estación actual
     const statsDoc = await statsRef.get();
-  
+
     if (statsDoc.exists) {
       // El documento de estadísticas ya existe
       const statsData = statsDoc.data();
-  
+
       if (statsData.date !== currentMonthYear) {
         // La fecha es diferente, crear un nuevo documento en la misma colección
         const newStatsRef = firestore.collection("stats").doc();
@@ -95,7 +95,7 @@ export const Registro = () => {
       };
       await statsRef.set(statsData);
     }
-  };  
+  };
 
   const handleChange = (selectedOption) => {
     generateVisits(selectedOption);
@@ -125,7 +125,9 @@ export const Registro = () => {
       wait_time: 0,
     };
 
-    const patientRef = await firestore.collection("patients").add(formattedPatient);
+    const patientRef = await firestore
+      .collection("patients")
+      .add(formattedPatient);
     const ptNo = patientRef.id;
     const updatedPatient = { ...formattedPatient, pt_no: ptNo };
 

--- a/src/pages/Registro.js
+++ b/src/pages/Registro.js
@@ -119,7 +119,7 @@ export const Registro = () => {
       pt_no: "",
       reason_for_visit: patient.motivo,
       age: patient.edad,
-      tel: patient.tel,
+      tel: patient.tel ?? null,
       start_time: new Date(),
       stop_time: new Date(),
       wait_time: 0,

--- a/src/pages/Registro.js
+++ b/src/pages/Registro.js
@@ -118,7 +118,7 @@ export const Registro = () => {
       plan_of_care: patientPlanOfCare,
       pt_no: "",
       reason_for_visit: patient.motivo,
-      age: patient.edad,
+      age: patient.edad !== undefined ? patient.edad : null,
       tel: patient.tel ?? null,
       start_time: new Date(),
       stop_time: new Date(),

--- a/src/pages/Registro.js
+++ b/src/pages/Registro.js
@@ -43,7 +43,7 @@ export const Registro = () => {
         procedure_end: new Date(),
         procedure_start: new Date(),
         station: visit,
-        status: "waiting",
+        status: "pending",
         wait_end: new Date(),
         wait_start: new Date(),
       };

--- a/src/pages/Registro.js
+++ b/src/pages/Registro.js
@@ -177,26 +177,45 @@ export const Registro = () => {
               <Form.Item
                 label="Edad"
                 name="edad"
-                rules={[{ required: true, message: "Ingrese su edad" }]}
-              >
-                <InputNumber min={1} max={99} />
-              </Form.Item>
-            </Col>
-          </Row>
-          <Row gutter={24}>
-            <Col xs={24} sm={24}>
-              <Form.Item
-                label="Número de télefono"
-                name="tel"
                 rules={[
                   {
-                    required: true,
-                    message: "Ingrese un número teléfonico",
-                    pattern: new RegExp(/^\d+$/),
+                    validator: (_, value) => {
+                      if (value === undefined || value === "") {
+                        return Promise.resolve();
+                      }
+                      if (value >= 1 && value <= 99) {
+                        return Promise.resolve();
+                      }
+                      return Promise.reject(
+                        new Error("Ingrese una edad válida")
+                      );
+                    },
                   },
                 ]}
               >
-                <Input type={"tel"} />
+                <InputNumber min={1} max={99} />
+              </Form.Item>
+
+              <Form.Item
+                label="Número de teléfono"
+                name="tel"
+                rules={[
+                  {
+                    validator: (_, value) => {
+                      if (value === undefined || value === "") {
+                        return Promise.resolve();
+                      }
+                      if (/^\d+$/.test(value)) {
+                        return Promise.resolve();
+                      }
+                      return Promise.reject(
+                        new Error("Ingrese un número telefónico válido")
+                      );
+                    },
+                  },
+                ]}
+              >
+                <Input type="tel" />
               </Form.Item>
             </Col>
           </Row>

--- a/src/pages/RouterPage.js
+++ b/src/pages/RouterPage.js
@@ -52,7 +52,7 @@ export const RouterPage = () => {
     {
       key: "5",
       icon: <BarChartOutlined />,
-      label: <Link to="/estadisticas">Estadisticas de hoy</Link>,
+      label: <Link to="/estadisticas">Estadisticas</Link>,
     },
   ];
 

--- a/src/pages/Stats.js
+++ b/src/pages/Stats.js
@@ -20,10 +20,12 @@ const fetchStatsData = async () => {
   const statsSnapshot = await getDocs(statsCollection);
 
   statsSnapshot.forEach((doc) => {
-    const { station_type, number_of_patients } = doc.data();
+    const { station_type, number_of_patients, avg_waiting_time, avg_procedure_time } = doc.data();
     const dataEntry = {
       station_type,
       Pacientes: number_of_patients,
+      TiempoPromedioEspera: avg_waiting_time,
+      TiempoPromedioProcedimiento: avg_procedure_time,
       fill: "#8884d8", // Opcional: Asigna colores personalizados a cada barra
     };
     statsData.push(dataEntry);
@@ -80,8 +82,8 @@ const Stats = () => {
       <h2 style={{ textAlign: "center", marginBottom: "10px" }}>
         Total de visitas por servicio
       </h2>
-      <div style={{ width: "100%", height: "80%", position: "relative" }}>
-        <ResponsiveContainer width="100%" height="100%">
+      <div style={{ display: "flex", width: "100%", height: "80%" }}>
+        <ResponsiveContainer width="50%" height="100%">
           <BarChart data={statsData}>
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey="station_type" />
@@ -92,6 +94,31 @@ const Stats = () => {
               {statsData.map((entry, index) => (
                 <Cell
                   key={`cell-${index}`}
+                  fill={barColors[entry.station_type]}
+                />
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+        <ResponsiveContainer width="50%" height="100%">
+          <BarChart data={statsData}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="station_type" />
+            <YAxis />
+            <Tooltip />
+            <Legend />
+            <Bar dataKey="TiempoPromedioEspera">
+              {statsData.map((entry, index) => (
+                <Cell
+                  key={`cell-${index}`}
+                  fill={barColors[entry.station_type]}
+                />
+              ))}
+            </Bar>
+            <Bar dataKey="TiempoPromedioProcedimiento">
+              {statsData.map((entry, index) => (
+                <Cell
+                  key={`cell2-${index}`}
                   fill={barColors[entry.station_type]}
                 />
               ))}

--- a/src/pages/Stats.js
+++ b/src/pages/Stats.js
@@ -20,7 +20,12 @@ const fetchStatsData = async () => {
   const statsSnapshot = await getDocs(statsCollection);
 
   statsSnapshot.forEach((doc) => {
-    const { station_type, number_of_patients, avg_waiting_time, avg_procedure_time } = doc.data();
+    const {
+      station_type,
+      number_of_patients,
+      avg_waiting_time,
+      avg_procedure_time,
+    } = doc.data();
     const dataEntry = {
       station_type,
       Pacientes: number_of_patients,

--- a/src/pages/Stats.js
+++ b/src/pages/Stats.js
@@ -29,8 +29,8 @@ const fetchStatsData = async () => {
     const dataEntry = {
       station_type,
       Pacientes: number_of_patients,
-      TiempoPromedioEspera: avg_waiting_time,
-      TiempoPromedioProcedimiento: avg_procedure_time,
+      "Tiempo Promedio Espera": avg_waiting_time,
+      "Tiempo Promedio Procedimiento": avg_procedure_time,
       fill: "#8884d8", // Opcional: Asigna colores personalizados a cada barra
     };
     statsData.push(dataEntry);
@@ -112,7 +112,7 @@ const Stats = () => {
             <YAxis />
             <Tooltip />
             <Legend />
-            <Bar dataKey="TiempoPromedioEspera">
+            <Bar dataKey="Tiempo Promedio Espera">
               {statsData.map((entry, index) => (
                 <Cell
                   key={`cell-${index}`}
@@ -120,7 +120,7 @@ const Stats = () => {
                 />
               ))}
             </Bar>
-            <Bar dataKey="TiempoPromedioProcedimiento">
+            <Bar dataKey="Tiempo Promedio Procedimiento">
               {statsData.map((entry, index) => (
                 <Cell
                   key={`cell2-${index}`}

--- a/src/pages/Turno.js
+++ b/src/pages/Turno.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Table, Image } from "antd";
+import { Table, Image, Typography } from "antd";
 import { firestore } from "./../helpers/firebaseConfig";
 import { useHideMenu } from "../hooks/useHideMenu";
 import StationEnum from "../helpers/stationEnum";

--- a/src/pages/Turno.js
+++ b/src/pages/Turno.js
@@ -12,6 +12,8 @@ import {
 import { firestore } from "./../helpers/firebaseConfig";
 import { useHideMenu } from "../hooks/useHideMenu";
 import StationEnum from "../helpers/stationEnum";
+import Footer from "./Footer";
+
 const { Title } = Typography;
 
 export const Turno = () => {
@@ -230,6 +232,7 @@ export const Turno = () => {
         offsetScroll={3}
         rowClassName={getRowClassName}
       />
+      <Footer />
     </>
   );
 };

--- a/src/pages/Turno.js
+++ b/src/pages/Turno.js
@@ -107,18 +107,7 @@ export const Turno = () => {
         fixed: "right",
         align: "center",
         render: (pt_no) => {
-          let remainingTime = countdown[pt_no] || 0;
-      
-          // Verificar si el remainingTime debe ser avg_procedure_time
-          const item = data.find((item) => item.pt_no === pt_no);
-          if (item) {
-            const inProcessItem = item.plan_of_care.find(
-              (planItem) => planItem.status === 'in_process'
-            );
-            if (inProcessItem) {
-              remainingTime = item.avg_procedure_time;
-            }
-          }
+          const remainingTime = countdown[pt_no] || 0;
       
           return (
             <span
@@ -166,25 +155,14 @@ export const Turno = () => {
           setData(initialData);
         }
   
-        let countdownData =
-          JSON.parse(localStorage.getItem("countdownData")) || {};
         const updatedCountdownData = {};
   
         initialData.forEach((item) => {
           const pt_no = item.pt_no;
-          const avgWaitingTime = item.avg_waiting_time || 0;
-          let remainingTime = Math.max(Math.ceil(avgWaitingTime), 0);
+          const avgWaitingTime = item.avg_time || 0;
+          const remainingTime = Math.max(Math.ceil(avgWaitingTime), 0);
   
-          // Verificar si algún objeto en el arreglo plan_of_care tiene status 'in_process'
-          const inProcessItem = item.plan_of_care.find(
-            (planItem) => planItem.status === 'in_process'
-          );
-  
-          if (inProcessItem) {
-            remainingTime = item.avg_procedure_time;
-          }
-  
-          updatedCountdownData[pt_no] = countdownData[pt_no] || remainingTime;
+          updatedCountdownData[pt_no] = remainingTime;
   
           const countdownInterval = setInterval(() => {
             updatedCountdownData[pt_no] = Math.max(
@@ -203,10 +181,7 @@ export const Turno = () => {
           }
         });
   
-        countdownData = updatedCountdownData;
-        localStorage.setItem("countdownData", JSON.stringify(countdownData));
-  
-        setCountdown(countdownData);
+        setCountdown(updatedCountdownData);
   
         const unsubscribe = collectionRef.onSnapshot((snapshot) => {
           const updatedData = snapshot.docs.map((doc) => doc.data());

--- a/src/pages/Turno.js
+++ b/src/pages/Turno.js
@@ -105,15 +105,16 @@ export const Turno = () => {
         key: "countdown",
         width: 100,
         fixed: "right",
+        align: "center", // Agregado para centrar el contenido
         render: (pt_no) => {
           const remainingTime = countdown[pt_no] || 0;
           return (
-            <span style={{ color: remainingTime === 0 ? "red" : "inherit" }}>
+            <span style={{ color: remainingTime === 0 ? "red" : "inherit", fontSize: "18px" }}>
               {remainingTime} min
             </span>
           );
         },
-      },
+      },         
     ];
 
     const dataSource = extractedPlanOfCare.map((item) => {
@@ -155,7 +156,7 @@ export const Turno = () => {
         initialData.forEach((item) => {
           const pt_no = item.pt_no;
           const avgWaitingTime = item.avg_waiting_time || 0;
-          const remainingTime = Math.max(Math.ceil(avgWaitingTime / 60), 0);
+          const remainingTime = Math.max(Math.ceil(avgWaitingTime), 0);
 
           updatedCountdownData[pt_no] = countdownData[pt_no] || remainingTime;
 

--- a/src/pages/Turno.js
+++ b/src/pages/Turno.js
@@ -23,7 +23,6 @@ export const Turno = () => {
   const [direction, setDirection] = useState("horizontal");
   const [countdown, setCountdown] = useState({});
 
-
   const renderStatusIcon = (status) => {
     let statusIcon = null;
     switch (status) {
@@ -136,7 +135,7 @@ export const Turno = () => {
 
   useEffect(() => {
     let isMounted = true;
-  
+
     const fetchData = async () => {
       try {
         const collectionRef = firestore.collection("patients");
@@ -144,48 +143,52 @@ export const Turno = () => {
         const initialData = snapshot.docs.map((doc) => {
           return doc.data();
         });
-  
+
         if (isMounted) {
           setData(initialData);
         }
-  
-        let countdownData = JSON.parse(localStorage.getItem("countdownData")) || {};
+
+        let countdownData =
+          JSON.parse(localStorage.getItem("countdownData")) || {};
         const updatedCountdownData = {};
-  
+
         initialData.forEach((item) => {
           const pt_no = item.pt_no;
           const avgWaitingTime = item.avg_waiting_time || 0;
           const remainingTime = Math.max(Math.ceil(avgWaitingTime / 60), 0);
-  
+
           updatedCountdownData[pt_no] = countdownData[pt_no] || remainingTime;
-  
+
           const countdownInterval = setInterval(() => {
-            updatedCountdownData[pt_no] = Math.max(updatedCountdownData[pt_no] - 1, 0);
+            updatedCountdownData[pt_no] = Math.max(
+              updatedCountdownData[pt_no] - 1,
+              0
+            );
             setCountdown({ ...updatedCountdownData });
-  
+
             if (updatedCountdownData[pt_no] === 0) {
               clearInterval(countdownInterval);
             }
           }, 60000);
-  
+
           if (updatedCountdownData[pt_no] === 0) {
             clearInterval(countdownInterval);
           }
         });
-  
+
         countdownData = updatedCountdownData;
         localStorage.setItem("countdownData", JSON.stringify(countdownData));
-  
+
         setCountdown(countdownData);
-  
+
         const unsubscribe = collectionRef.onSnapshot((snapshot) => {
           const updatedData = snapshot.docs.map((doc) => doc.data());
-  
+
           if (isMounted) {
             setData(updatedData);
           }
         });
-  
+
         return () => {
           unsubscribe();
           isMounted = false;
@@ -194,13 +197,13 @@ export const Turno = () => {
         console.log(error);
       }
     };
-  
+
     fetchData();
-  
+
     return () => {
       isMounted = false;
     };
-  }, []);  
+  }, []);
 
   const getRowClassName = (record, index) => {
     return index % 2 === 0 ? "even-row" : "odd-row";

--- a/src/pages/Turno.js
+++ b/src/pages/Turno.js
@@ -108,7 +108,11 @@ export const Turno = () => {
         fixed: "right",
         render: (pt_no) => {
           const remainingTime = countdown[pt_no] || 0;
-          return <span>{remainingTime}</span>;
+          return (
+            <span style={{ color: remainingTime === 0 ? "red" : "inherit" }}>
+              {remainingTime} min
+            </span>
+          );
         },
       },
     ];
@@ -145,21 +149,32 @@ export const Turno = () => {
           setData(initialData);
         }
   
-        const countdownData = {};
+        let countdownData = JSON.parse(localStorage.getItem("countdownData")) || {};
+        const updatedCountdownData = {};
+  
         initialData.forEach((item) => {
+          const pt_no = item.pt_no;
           const avgWaitingTime = item.avg_waiting_time || 0;
-          countdownData[item.pt_no] = avgWaitingTime;
+          const remainingTime = Math.max(Math.ceil(avgWaitingTime / 60), 0);
   
-          // Start countdown timer for each patient
+          updatedCountdownData[pt_no] = countdownData[pt_no] || remainingTime;
+  
           const countdownInterval = setInterval(() => {
-            countdownData[item.pt_no] = Math.max(countdownData[item.pt_no] - 1, 0);
-            setCountdown({ ...countdownData });
+            updatedCountdownData[pt_no] = Math.max(updatedCountdownData[pt_no] - 1, 0);
+            setCountdown({ ...updatedCountdownData });
   
-            if (countdownData[item.pt_no] === 0) {
+            if (updatedCountdownData[pt_no] === 0) {
               clearInterval(countdownInterval);
             }
-          }, 1000); // Update countdown every second
+          }, 60000);
+  
+          if (updatedCountdownData[pt_no] === 0) {
+            clearInterval(countdownInterval);
+          }
         });
+  
+        countdownData = updatedCountdownData;
+        localStorage.setItem("countdownData", JSON.stringify(countdownData));
   
         setCountdown(countdownData);
   


### PR DESCRIPTION
**Description**

- Algoritmo que guarda en segundos a nivel de colección de stats el tiempo de espera por paciente en cada clínica. Los segundos se van guardando en arreglos "procedure_time_data" y "waiting_time_data"; próximamente, los datos de cada arreglo se suman y se dividen entre el numero de pacientes por clínica.
- A nivel de la colección "patients", hay una variable llamada "avg_time", la cual es, en tiempo real, el promedio de cualquier estatus próximo a nivel de clínica, en minutos. Por ejemplo, si un paciente tiene el estatus "waiting" en X clínica, el "avg_time" será igual al tiempo promedio de espera en esa clínica. Una vez que ese estatus cambie a "in_process", el "avg_time" será igual al tiempo promedio de atención médica en esa clínica para ese estatus. Si el paciente no tiene ninguno de esos estatus, es decir, si el paciente está pagando o ha finalizado su atención médica, el "avg_time" será igual a 0 (aquí se maneja en minutos para colocarle en columna "Tiempo de espera", de resolución a minutos)
- Ahora edad y teléfono son campos opcionales
- Mas gráficos para waiting e in_process status por clínica 

**Jira issue**

-  https://alfarero.atlassian.net/browse/PFM-9

**Feature**
feat: ✨ average waiting/in_process times
feat: ✨ simpler footer showing averages
feat: ✨ more graphs and cards about avg times
feat: ✨ count down according with avg_waiting_time per patient
feat: ✨ switching between avg_waiting_time & avg_procedure_time

**Fixes** 
fix: NaN when calculating average, solved
fix: age, number unrequired fields & pay status en escritorio
fix: accepting null ages, removing saving times in localStorage


