### PR TITLE
[Feature PFM] CG | Development push: timestamps, Jun 30, 2023

### DIFF
--- a/src/helpers/updateStationStatus.js
+++ b/src/helpers/updateStationStatus.js
@@ -81,6 +81,15 @@ export const handleStatusChange = async (value, hoveredRowKey, station) => {
 
           const { waiting_time_data, procedure_time_data, number_of_patients } =
             statsData;
+          const options = {
+            day: "numeric",
+            month: "numeric",
+            year: "numeric",
+            hour: "numeric",
+            minute: "numeric",
+            second: "numeric",
+            timeZoneName: "short",
+          };
 
           if (waiting_time_data && number_of_patients) {
             const validWaitingTimeData = waiting_time_data.filter(
@@ -97,7 +106,7 @@ export const handleStatusChange = async (value, hoveredRowKey, station) => {
               .collection("patients")
               .doc(hoveredRowKey)
               .update({
-                avg_time: Math.floor(waitingAverage / 60),
+                avg_time: new Date().toLocaleString("en-US", options),
               });
           }
 
@@ -118,7 +127,7 @@ export const handleStatusChange = async (value, hoveredRowKey, station) => {
                 .collection("patients")
                 .doc(hoveredRowKey)
                 .update({
-                  avg_time: Math.floor(procedureAverage / 60),
+                  avg_time: new Date().toLocaleString("en-US", options),
                 });
             } else if (value !== "in_process" && value !== "waiting") {
               await firestore.collection("patients").doc(hoveredRowKey).update({
@@ -157,4 +166,3 @@ export const handleDelete = async (hoveredRowKey) => {
     console.log("No such document!");
   }
 };
-

--- a/src/pages/Escritorio.js
+++ b/src/pages/Escritorio.js
@@ -318,6 +318,15 @@ export const Escritorio = () => {
 
       const { waiting_time_data, procedure_time_data, number_of_patients } =
         statsData;
+      const options = {
+        day: "numeric",
+        month: "numeric",
+        year: "numeric",
+        hour: "numeric",
+        minute: "numeric",
+        second: "numeric",
+        timeZoneName: "short",
+      };
 
       if (waiting_time_data && number_of_patients) {
         const validWaitingTimeData = waiting_time_data.filter(
@@ -336,7 +345,7 @@ export const Escritorio = () => {
           .collection("patients")
           .doc(record.pt_no)
           .update({
-            avg_time: Math.floor(waitingAverage / 60),
+            avg_time: new Date().toLocaleString("en-US", options),
           });
       }
 
@@ -357,7 +366,7 @@ export const Escritorio = () => {
             .collection("patients")
             .doc(record.pt_no)
             .update({
-              avg_time: Math.floor(procedureAverage / 60),
+              avg_time: new Date().toLocaleString("en-US", options),
             });
         } else if (value !== "in_process" && value !== "waiting") {
           await firestore.collection("patients").doc(record.pt_no).update({

--- a/src/translations/en/global.json
+++ b/src/translations/en/global.json
@@ -39,7 +39,7 @@
   "logout": "Logout",
   "currentService": "You are offering the service: ",
   "patient": "Patient",
-  "waitingTime": "Waiting time",
+  "waitingTime": "Initial waiting time",
   "action": "Action",
   "modifyStatus": "CHANGE STATUS",
   "delete": "Delete",

--- a/src/translations/es/global.json
+++ b/src/translations/es/global.json
@@ -39,7 +39,7 @@
   "logout": "Salir",
   "currentService": "Usted está ofreciendo el servicio: ",
   "patient": "Paciente",
-  "waitingTime": "Tiempo de espera",
+  "waitingTime": "Tiempo de espera inicial",
   "action": "Acción",
   "modifyStatus": "CAMBIAR ESTATUS",
   "delete": "Eliminar",


### PR DESCRIPTION
**Description**

- Cuando se modifica el status 'waiting' o 'in_process', se crea un timestamp con formato universal (UTC-6), que se actualiza en tiempo real cada que cambias a alguno de esos status. Es prácticamente lo mismo que contar para arriba, solo que no haces un desorden con las operaciones en ms,y resolución en minutos. Me imagino que un humano puede calcular que si su timestamp es de "6/30/2023, 8:06:46 AM CST", su tiempo en la fila es de 10 minutos (si son las 8:16 AM). Es un dato mas estable, no cambia por minuto así que es menos pesada la operación y a fin de cuentas lo mismo, pero mas fácil y entendible también para pacientes, me imagino

**Jira Issue**

https://alfarero.atlassian.net/browse/PFM-17

**Fix**

[bugfix: timestamp resolution]