### PR TITLE
[Bugfix PFM] CG | Development push: countup, July 2th, 2023

### DIFF
--- a/src/helpers/updateStationStatus.js
+++ b/src/helpers/updateStationStatus.js
@@ -80,6 +80,13 @@ export const handleStatusChange = async (value, hoveredRowKey, station) => {
           const { waiting_time_data, procedure_time_data, number_of_patients } =
             statsData;
 
+            await firestore
+            .collection("patients")
+            .doc(hoveredRowKey)
+            .update({
+              avg_time: Math.floor(Date.now() / 1000)
+            });
+
 
           if (waiting_time_data && number_of_patients) {
             const validWaitingTimeData = waiting_time_data.filter(
@@ -92,12 +99,6 @@ export const handleStatusChange = async (value, hoveredRowKey, station) => {
             await statsDocRef.update({
               avg_waiting_time: waitingAverage,
             });
-            await firestore
-              .collection("patients")
-              .doc(hoveredRowKey)
-              .update({
-                avg_time: Math.floor(Date.now() / 1000)
-              });
           }
 
           if (number_of_patients) {

--- a/src/helpers/updateStationStatus.js
+++ b/src/helpers/updateStationStatus.js
@@ -53,8 +53,7 @@ export const handleStatusChange = async (value, hoveredRowKey, station) => {
 
           if (
             value === "waiting" &&
-            updatedItem.wait_start &&
-            updatedItem.wait_end
+            updatedItem.wait_start
           ) {
             const waitDifference = Math.abs(updatedItem.waiting_time);
             await statsDocRef.update({
@@ -67,8 +66,7 @@ export const handleStatusChange = async (value, hoveredRowKey, station) => {
 
           if (
             value === "in_process" &&
-            updatedItem.procedure_start &&
-            updatedItem.procedure_end
+            updatedItem.procedure_start
           ) {
             const inProcessDifference = Math.abs(updatedItem.procedure_time);
             await statsDocRef.update({
@@ -81,15 +79,7 @@ export const handleStatusChange = async (value, hoveredRowKey, station) => {
 
           const { waiting_time_data, procedure_time_data, number_of_patients } =
             statsData;
-          const options = {
-            day: "numeric",
-            month: "numeric",
-            year: "numeric",
-            hour: "numeric",
-            minute: "numeric",
-            second: "numeric",
-            timeZoneName: "short",
-          };
+
 
           if (waiting_time_data && number_of_patients) {
             const validWaitingTimeData = waiting_time_data.filter(
@@ -106,11 +96,11 @@ export const handleStatusChange = async (value, hoveredRowKey, station) => {
               .collection("patients")
               .doc(hoveredRowKey)
               .update({
-                avg_time: new Date().toLocaleString("en-US", options),
+                avg_time: Math.floor(Date.now() / 1000)
               });
           }
 
-          if (procedure_time_data && number_of_patients) {
+          if (number_of_patients) {
             const validProcedureTimeData = procedure_time_data.filter(
               (time) => !isNaN(time)
             );
@@ -127,7 +117,7 @@ export const handleStatusChange = async (value, hoveredRowKey, station) => {
                 .collection("patients")
                 .doc(hoveredRowKey)
                 .update({
-                  avg_time: new Date().toLocaleString("en-US", options),
+                  avg_time: Math.floor(Date.now() / 1000)
                 });
             } else if (value !== "in_process" && value !== "waiting") {
               await firestore.collection("patients").doc(hoveredRowKey).update({

--- a/src/pages/Anfitrion.js
+++ b/src/pages/Anfitrion.js
@@ -413,7 +413,16 @@ export const Anfitrion = () => {
         dataIndex: "avg_time",
         key: "patient",
         width: 100,
+        align: "center",
         fixed: "right",
+        render: (avg_time) => {
+          const displayValue = isNaN(avg_time) ? 0 : avg_time;
+          const style = {
+            fontSize: "18px",
+            color: displayValue === 0 ? "red" : "inherit",
+          };
+          return <span style={style}>{displayValue} min</span>;
+        },
       },
       {
         title: t("action"),
@@ -445,10 +454,16 @@ export const Anfitrion = () => {
       item.plan_of_care?.forEach((plan) => {
         stations[plan.station] = plan.status;
       });
+
+      const avg_time =
+        item.avg_time !== 0
+          ? Math.floor((Date.now() / 1000 - item.avg_time) / 60)
+          : 0;
+
       return {
         pt_no: item.pt_no,
         patient_name: item.patient_name,
-        avg_time: item.avg_time,
+        avg_time: avg_time,
         ...stations,
       };
     });

--- a/src/pages/Escritorio.js
+++ b/src/pages/Escritorio.js
@@ -290,8 +290,7 @@ export const Escritorio = () => {
 
       if (
         value === "waiting" &&
-        updatedItem.wait_start &&
-        updatedItem.wait_end
+        updatedItem.wait_start
       ) {
         const waitDifference = Math.abs(updatedItem.waiting_time);
         await statsDocRef.update({
@@ -304,8 +303,7 @@ export const Escritorio = () => {
 
       if (
         value === "in_process" &&
-        updatedItem.procedure_start &&
-        updatedItem.procedure_end
+        updatedItem.procedure_start
       ) {
         const inProcessDifference = Math.abs(updatedItem.procedure_time);
         await statsDocRef.update({
@@ -318,17 +316,8 @@ export const Escritorio = () => {
 
       const { waiting_time_data, procedure_time_data, number_of_patients } =
         statsData;
-      const options = {
-        day: "numeric",
-        month: "numeric",
-        year: "numeric",
-        hour: "numeric",
-        minute: "numeric",
-        second: "numeric",
-        timeZoneName: "short",
-      };
 
-      if (waiting_time_data && number_of_patients) {
+      if (number_of_patients) {
         const validWaitingTimeData = waiting_time_data.filter(
           (time) => !isNaN(time)
         );
@@ -345,7 +334,7 @@ export const Escritorio = () => {
           .collection("patients")
           .doc(record.pt_no)
           .update({
-            avg_time: new Date().toLocaleString("en-US", options),
+            avg_time: Math.floor(Date.now() / 1000),
           });
       }
 
@@ -366,7 +355,7 @@ export const Escritorio = () => {
             .collection("patients")
             .doc(record.pt_no)
             .update({
-              avg_time: new Date().toLocaleString("en-US", options),
+              avg_time: Math.floor(Date.now() / 1000),
             });
         } else if (value !== "in_process" && value !== "waiting") {
           await firestore.collection("patients").doc(record.pt_no).update({

--- a/src/pages/Escritorio.js
+++ b/src/pages/Escritorio.js
@@ -311,7 +311,6 @@ export const Escritorio = () => {
       const { waiting_time_data, procedure_time_data, number_of_patients } =
         statsData;
 
-      // Guardar el promedio también en la colección "patients"
       await firestore
         .collection("patients")
         .doc(record.pt_no)

--- a/src/pages/Escritorio.js
+++ b/src/pages/Escritorio.js
@@ -288,10 +288,7 @@ export const Escritorio = () => {
         (item) => item.station === currentStation
       );
 
-      if (
-        value === "waiting" &&
-        updatedItem.wait_start
-      ) {
+      if (value === "waiting" && updatedItem.wait_start) {
         const waitDifference = Math.abs(updatedItem.waiting_time);
         await statsDocRef.update({
           waiting_time_data: [
@@ -301,10 +298,7 @@ export const Escritorio = () => {
         });
       }
 
-      if (
-        value === "in_process" &&
-        updatedItem.procedure_start
-      ) {
+      if (value === "in_process" && updatedItem.procedure_start) {
         const inProcessDifference = Math.abs(updatedItem.procedure_time);
         await statsDocRef.update({
           procedure_time_data: [
@@ -317,6 +311,14 @@ export const Escritorio = () => {
       const { waiting_time_data, procedure_time_data, number_of_patients } =
         statsData;
 
+      // Guardar el promedio también en la colección "patients"
+      await firestore
+        .collection("patients")
+        .doc(record.pt_no)
+        .update({
+          avg_time: Math.floor(Date.now() / 1000),
+        });
+
       if (number_of_patients) {
         const validWaitingTimeData = waiting_time_data.filter(
           (time) => !isNaN(time)
@@ -328,14 +330,6 @@ export const Escritorio = () => {
         await statsDocRef.update({
           avg_waiting_time: waitingAverage,
         });
-
-        // Guardar el promedio también en la colección "patients"
-        await firestore
-          .collection("patients")
-          .doc(record.pt_no)
-          .update({
-            avg_time: Math.floor(Date.now() / 1000),
-          });
       }
 
       if (procedure_time_data && number_of_patients) {

--- a/src/pages/Turno.js
+++ b/src/pages/Turno.js
@@ -191,7 +191,16 @@ export const Turno = () => {
         dataIndex: "avg_time",
         key: "patient",
         width: 100,
+        align: "center",
         fixed: "right",
+        render: (avg_time) => {
+          const displayValue = isNaN(avg_time) ? 0 : avg_time;
+          const style = {
+            fontSize: "18px",
+            color: displayValue === 0 ? "red" : "inherit",
+          };
+          return <span style={style}>{displayValue} min</span>;
+        },
       },
     ];
 
@@ -200,10 +209,16 @@ export const Turno = () => {
       item.plan_of_care.forEach((plan) => {
         stations[plan.station] = plan.status;
       });
+
+      const avg_time =
+        item.avg_time !== 0
+          ? Math.floor((Date.now() / 1000 - item.avg_time) / 60)
+          : 0;
+
       return {
         pt_no: item.pt_no,
         patient_name: item.patient_name,
-        avg_time: item.avg_time,
+        avg_time: avg_time,
         ...stations,
       };
     });

--- a/src/translations/en/global.json
+++ b/src/translations/en/global.json
@@ -39,7 +39,7 @@
   "logout": "Logout",
   "currentService": "You are offering the service: ",
   "patient": "Patient",
-  "waitingTime": "Initial waiting time",
+  "waitingTime": "Waiting time",
   "action": "Action",
   "modifyStatus": "CHANGE STATUS",
   "delete": "Delete",

--- a/src/translations/es/global.json
+++ b/src/translations/es/global.json
@@ -39,7 +39,7 @@
   "logout": "Salir",
   "currentService": "Usted está ofreciendo el servicio: ",
   "patient": "Paciente",
-  "waitingTime": "Tiempo de espera inicial",
+  "waitingTime": "Tiempo de espera",
   "action": "Acción",
   "modifyStatus": "CAMBIAR ESTATUS",
   "delete": "Eliminar",


### PR DESCRIPTION
**Description**

- Countup per patient displayed when the status is 'waiting' or 'in_process', distinguishing between statuses. It has a resolution in minutes... the countup is derived from the subtraction of Date.now minus the start_time of the object with the status within the corresponding clinic

**Jira Issue**

https://alfarero.atlassian.net/browse/PFM-17

**Fix**

[bugfix: countup time with minute resolution]